### PR TITLE
Fix args passing from Java to Lua functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,67 @@
-*.sublime*
-*.class
+*.csproj.user
+bin
+obj
+target
+doc
+Version.java
+.cproject
+.classpath
+.metadata
+.project
+.settings
+.DS_Store
+*.pyc
+modules/.*
+target/
+aerospike/client_test-valgrind
 
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+*.suo
+*.pyc
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.out
+*.jar
+*.iml
+*.rar
+*.tar
+*.zip
+*.tgz
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+.bash_profile
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+
+# Mac OSX 
+xcuserdata
+*.xccheckout
+*.swp
+*~.nib

--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -21,7 +21,6 @@ else
 CFLAGS += -rdynamic
 endif
 
-
 CFLAGS += -I/usr/include
 
 LDFLAGS += -lssl -lcrypto -lpthread
@@ -32,33 +31,17 @@ else
 LDFLAGS += -lrt
 endif
 
-LUA_CPATH += $(or \
-    $(wildcard /usr/include/lua-5.1), \
-    $(wildcard /usr/include/lua5.1))
-
 ifeq ($(OS),Darwin)
 LUA_LIBPATH += $(or \
-    $(wildcard /usr/local/lib/liblua.5.1.dylib), \
-    $(wildcard /usr/local/lib/liblua.5.1.a), \
-    $(wildcard /usr/local/lib/liblua.dylib), \
-    $(wildcard /usr/local/lib/liblua.a), \
-	$(error Cannot find liblua 5.1) \
-    )
+        $(wildcard /usr/local/lib/liblua.dylib), \
+    $(wildcard /usr/local/lib/liblua.a))
 LUA_LIBDIR = $(dir LUA_LIBPATH)
 LUA_LIB = $(patsubst lib%,%,$(basename $(notdir $(LUA_LIBPATH))))
 else
 # Linux
 LUA_LIBPATH += $(or \
-    $(wildcard /usr/lib/liblua5.1.so), \
-    $(wildcard /usr/lib/liblua5.1.a), \
-    $(wildcard /usr/lib/x86_64-linux-gnu/liblua5.1.so), \
-    $(wildcard /usr/lib/x86_64-linux-gnu/liblua5.1.a), \
-    $(wildcard /usr/lib64/liblua-5.1.so), \
-    $(wildcard /usr/lib64/liblua-5.1.a), \
-    $(wildcard /usr/lib/liblua.so), \
-    $(wildcard /usr/lib/liblua.a), \
-	$(error Cannot find liblua 5.1) \
-    )
+     $(wildcard /usr/lib/liblua.so), \
+    $(wildcard /usr/lib/liblua.a))
 LUA_LIBDIR = $(dir LUA_LIBPATH)
 LUA_LIB = $(patsubst lib%,%,$(basename $(notdir $(LUA_LIBPATH))))
 endif
@@ -96,10 +79,8 @@ target:
 	mkdir $@
 
 target/expire_bin: expire_bin.c | target
-	$(CC) $(CFLAGS) -o $@ $^ /usr/lib/libaerospike.a $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $^ /usr/local/lib/libaerospike.a $(LDFLAGS)
 
 .PHONY: run
 run: build
 	./target/expire_bin
-
-

--- a/src/c/expire_bin.c
+++ b/src/c/expire_bin.c
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *	http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,217 +14,65 @@
  * limitations under the License.
  */
 
-#include <errno.h>
-#include <time.h>
+ //==========================================================
+// Includes
+//
 
-#include <aerospike/aerospike.h>
+#include <errno.h>
+
 #include <aerospike/aerospike_key.h>
 #include <aerospike/aerospike_scan.h>
 #include <aerospike/as_arraylist.h>
-#include <aerospike/as_error.h>
-#include <aerospike/as_integer.h>
-#include <aerospike/as_status.h>
-#include <aerospike/as_val.h>
-#include <aerospike/as_scan.h>
-#include <aerospike/as_key.h>
-#include <aerospike/as_map.h>
 #include <aerospike/aerospike_udf.h>
-#include <aerospike/as_config.h>
-#include <aerospike/as_string.h>
 #include <aerospike/as_hashmap.h>
 #include <aerospike/as_stringmap.h>
+#include <aerospike/aerospike_scan.h>
+
+//==========================================================
+// Constants
+//
 
 #define UDF_MODULE "expire_bin"
 #define UDF_USER_PATH "../../"
-const char UDF_FILE_PATH[] = UDF_USER_PATH UDF_MODULE ".lua";
-
 #define LOG(_fmt, _args...) { printf(_fmt "\n", ## _args); fflush(stdout); }
 
-bool register_udf(aerospike* p_as, const char* udf_file_path);
-void cleanup(aerospike * as, as_error * err, const as_policy_remove * policy, const as_key * key);
-void remove_test_record(aerospike* p_as);
+const char UDF_FILE_PATH[] = UDF_USER_PATH UDF_MODULE ".lua";
 
-/*
- * Attempt to retrieve values from list of bins. The bins
- * can be expire bins or normal bins.
- *
- * \param as The aerospike instance to use for this operation.
- * \param err The as_error to be populated if an error occurs.
- * \param policy The policy to use for this operation. If NULL, then the default policy will be used.
- * \param key The key of the record
- * \param arglist The list of bin names to retrieve values from.
- * \param result A list of bin values respective to the list of bin names passedin. if a bin is expired or empty, the
- *        corresponding index in the list will be NULL.
- * \return AEROSPIKE_OK if successful, otherwise an error.
- */
-
-as_hashmap 
-create_bin_map(const char* bin_name, const char* val, int64_t bin_ttl) 
-{
-	as_hashmap map;
-	as_hashmap_init(&map, 1);
-	as_stringmap_set_str((as_map *) &map, "bin", bin_name);
-	as_stringmap_set_str((as_map *) &map, "val", val);
-	as_stringmap_set_int64((as_map *) &map, "bin_ttl", bin_ttl);
-
-	return map;
-}
-
-as_val* 
-as_expbin_get(aerospike* as, as_error* err, const as_policy_apply* policy, const as_key* key, as_list* arglist, as_val* result)
-{
-	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "get", arglist, &result);
-	if (rc != AEROSPIKE_OK) {
-		LOG("as_expbin_get() returned %d - %s", err->code, err->message);
-		exit(1);
-	}
-
-	//LOG("%d RESULT %s", rc, as_val_tostring(result));
-	
-	return result;
-}
-
-/*
- * Create or update expire bins. If bin_ttl is not NULL
- * 	all newly created bins will be expire bins otherwise, only normal bins will be created
- * 	and existing expire bins will be updated. Note: existing expire bins will not be converted
- * 	into normal bins if bin_ttl is NULL.
- *
- * \param as The aerospike instance to use for this operation.
- * \param err The as_error to be populated if an error occurs.
- * \param policy The policy to use for this operation. If NULL, then the default policy will be used.
- * \param key The key of the record
- * \param arglist The as_list containing the following:
- *   - bin name - char* with bin name
- *   - val - value to put inside bin
- *   - bin_ttl - expiration time in seconds or -1 for no expiration
- * \param result - 0 if successfully written, 1 otherwise
- *
- * \return AEROSPIKE_OK if successful, otherwise an error.
- */
-as_status
-as_expbin_put(aerospike* as, as_error* err, const as_policy_apply* policy, const as_key* key, char* bin, as_val* val, int bin_ttl, as_val** result)
-{
-	as_arraylist arglist;
-	as_arraylist_inita(&arglist, 4);
-	as_arraylist_append_str(&arglist, bin);
-	as_arraylist_append(&arglist, val);
-	as_arraylist_append_int64(&arglist, bin_ttl);
-
-	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "put", (as_list*)&arglist, result);
-	if (rc != AEROSPIKE_OK) {
-		LOG("as_expbin_put() returned %d - %s", err->code, err->message);
-	}
-	return rc;
-}
-
-/* Batch create or update expire bins for a given key. Use the as_map
- *		{'bin' : bin_name, 'val' : bin_value, 'bin_ttl' : ttl}
- * to store each put operation. Omit the bin_ttl to turn bin creation off.
- *
- * \param as The aerospike instance to use for this operation.
- * \param err The as_error to be populated if an error occurs.
- * \param policy The policy to use for this operation. If NULL, then the default policy will be used.
- * \param key The key of the record
- * \param arglist The list of as_maps in the following form: {'bin' : bin_name, 'val' : bin_value, 'bin_ttl' : ttl}
- * \param result - 0 if all ops succeed, 1 otherwise
- * 
- * \return AEROSPIKE_OK if successful, otherwise an error
- */
-as_status 
-as_expbin_puts(aerospike* as, as_error* err, const as_policy_apply* policy, const as_key* key, as_list* arglist, as_val* result) 
-{
-	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "puts", arglist, &result);
-	if (rc != AEROSPIKE_OK) {
-		LOG("as_expbin_puts() returned %d - %s", err->code, err->message);
-	}
-	return rc;
-}
-
-/*
- * Batch update the bin TTLs. Us this method to change or reset the bin TTL of
- * multiple bins in a record. Use a dict to store each touch operation.
- *
- * \param as The aerospike instance to use for this operation.
- * \param err The as_error to be populated if an error occurs.
- * \param policy The policy to use for this operation. If NULL, then the default policy will be used. 
- * \param key The key of the record
- * \param arglist The list of as_maps in the following form: {'bin' : bin_name, 'bin_ttl' : ttl}
- * \param result - 0 if all ops succeed, 1 otherwise
- * 
- * \return AEROSPIKE_OK if successful, otherwise an error
- */
-as_status 
-as_expbin_touch(aerospike* as, as_error* err, const as_policy_apply* policy, const as_key* key, as_list* arglist, as_val* result) 
-{
-	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "touch", arglist, &result);
-	if (rc != AEROSPIKE_OK) {
-		LOG("as_expbin_touch() returned %d - %s", err->code, err->message);	
-	}
-	return rc;
-}
-
-/*
- * Get the time bin will expire in seconds.
- *
- * \param as The aerospike instance to use for this operation.
- * \param err The as_error to be populated if an error occurs.
- * \param policy The policy to use for this operation. If NULL, then the default policy will be used. 
- * \param key The key of the record
- * \param arglist the bin name to check
- * \param result bin time to expire in seconds
- * 
- * \return AEROSPIKE_OK if successful, otherwise an error
- */
-as_val*
-as_expbin_ttl(aerospike* as, as_error* err, const as_policy_apply* policy, const as_key* key, const char* bin_name, as_val* result) 
-{
-	as_arraylist arglist;
-	as_arraylist_inita(&arglist, 1);
-	as_arraylist_append_str(&arglist, bin_name);
-
-	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "ttl", (as_list*) &arglist, &result);
-	if (rc != AEROSPIKE_OK) {
-		LOG("as_expbin_ttl() returned %d - %s", err->code, err->message);	
-	}
-	return result;
-}
-
-/* 
- * Perform a background scan and remove all expired bins
- * 
- * \param as The aerospike instance to use for this operation.
- * \param err The as_error to be populated if an error occurs
- * \param policy The policy to use for this operation. If NULL, then the default policy will be used.
- * \param scan as_scan to execute scan on
- * \param binlist list of bins to clean
- *
- * \return scan_id if successful, NULL if an error occurred.
- */
-uint64_t
-as_expbin_clean(aerospike* as, as_error* err, const as_policy_scan* policy, as_scan* scan, as_list* binlist)
-{
-	uint64_t scan_id;
-	if (as_scan_apply_each(scan, UDF_MODULE, "clean", binlist) != true) {
-		LOG("UDF apply failed");
-	}
-	as_status rc = aerospike_scan_background(as, err, policy, scan, &scan_id);
-	if (rc != AEROSPIKE_OK) {
-		LOG("as_expbin_clean() returned %d - %s", err->code, err->message);
-		exit(1);
-	} else {
-		return scan_id;
-	}
-}
+// Namespace, Set, and Key	
+const char DEFAULT_NAMESPACE[] = "test";
+const char DEFAULT_SET[] = "expireBin";
+const char DEFAULT_KEY_STR[] = "testKey";
+// Based on current server limit
+char eb_namespace[32]; 
+char eb_set[64];
+char eb_key_str[1024];
 
 //==========================================================
-// Expire Bin Example
+// Forward Declarations
+//
+
+as_val* as_expbin_get(aerospike* as, as_error* err, as_policy_apply* policy, as_key* key, as_list* arglist, as_val* result);
+void as_expbin_put(aerospike* as, as_error* err, as_policy_apply* policy, as_key* key, char* bin, as_val* val, uint64_t bin_ttl, as_val* result);
+void as_expbin_puts(aerospike* as, as_error* err, as_policy_apply* policy, as_key* key, as_list* arglist, as_val* result);
+void as_expbin_touch(aerospike* as, as_error* err, as_policy_apply* policy, as_key* key, as_list* arglist, as_val* result);
+as_val* as_expbin_ttl(aerospike* as, as_error* err, as_policy_apply* policy, as_key* key, char* bin_name, as_val* result);
+void as_expbin_clean(aerospike* as, as_error* err, const as_policy_scan* policy, as_scan* scan, as_list* binlist);
+as_hashmap create_bin_map(char* bin_name, char* val, int64_t bin_ttl);
+bool register_udf(aerospike* p_as, const char* udf_file_path);
+void cleanup(aerospike* as, as_error* err, as_policy_remove* policy, as_key* key);
+
+//==========================================================
+// Expire Bin C Example.
 //  
 
 int
 main(int argc, char* argv[]) 
 {
 	LOG("This is a demo of the expirable bin module for C");
+
+	strcpy(eb_namespace, DEFAULT_NAMESPACE);
+	strcpy(eb_set, DEFAULT_SET);
+	strcpy(eb_key_str, DEFAULT_KEY_STR);
 
 	aerospike as;
 	as_config config;
@@ -235,6 +83,7 @@ main(int argc, char* argv[])
 	aerospike_init(&as, &config);
 
 	LOG("Connecting to Aerospike server...");
+	
 	if (aerospike_connect(&as, &err) != AEROSPIKE_OK) {
 		LOG("error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
 		exit(1);
@@ -243,9 +92,12 @@ main(int argc, char* argv[])
 	LOG("Connected!");
 
 	as_key testKey;
+
+	// Start clean.
+	aerospike_key_remove(&as, &err, NULL, &testKey);
 	
-	if (as_key_init_str(&testKey, "test", "expireBin", "eb") == NULL) {
-		LOG("Key was not initiated.");
+	if (as_key_init_str(&testKey, eb_namespace, eb_set, eb_key_str) == NULL) {
+		LOG("Key was not initiated");
 		exit(1);
 	}
 
@@ -261,49 +113,31 @@ main(int argc, char* argv[])
 
 	as_val* result = NULL;
 	as_string val;
-	as_status rc;
 	as_arraylist arglist;
 
 	LOG("Creating expire bins...");
 	
 	as_string_init(&val, "Hello World.", false);
-	rc = as_expbin_put(&as, &err, NULL, &testKey, "TestBin1", (as_val*) &val, -1, &result);
-	if (rc != AEROSPIKE_OK) {
-		LOG("error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
-		exit(1);
-	}
+	as_expbin_put(&as, &err, NULL, &testKey, "TestBin1", (as_val*)&val, -1, result);
 
 	as_string_init(&val, "I don't expire.", false);
-	rc = as_expbin_put(&as, &err, NULL, &testKey, "TestBin2", (as_val*) &val, -1, &result);
-	if (rc != AEROSPIKE_OK) {
-		LOG("error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
-		exit(1);
-	}
+	as_expbin_put(&as, &err, NULL, &testKey, "TestBin2", (as_val*)&val, -1, result);
 
 	as_string_init(&val, "I will expire soon.", false);
-	rc = as_expbin_put(&as, &err, NULL, &testKey, "TestBin3", (as_val*) &val, 5, &result);
-	if (rc != AEROSPIKE_OK) {
-		LOG("error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
-		exit(1);
-	}
+	as_expbin_put(&as, &err, NULL, &testKey, "TestBin3", (as_val*)&val, 5, result);
 
 	as_hashmap map1, map2; 
 	as_arraylist_inita(&arglist, 2);
 
 	map1 = create_bin_map("TestBin4", "Good Morning.", 100); 
-	as_val_reserve((as_map *) &map1);
-	as_arraylist_append(&arglist, (as_val *)((as_map *) &map1));
+	as_val_reserve((as_map *)&map1);
+	as_arraylist_append(&arglist, (as_val *)((as_map *)&map1));
 
 	map2 = create_bin_map("TestBin5", "Good Night.", 0); 
-	as_val_reserve((as_map *) &map2);
-	as_arraylist_append(&arglist, (as_val *)((as_map *) &map2));
+	as_val_reserve((as_map *)&map2);
+	as_arraylist_append(&arglist, (as_val *)((as_map *)&map2));
 
-	rc = as_expbin_puts(&as, &err, NULL, &testKey, (as_list*) &arglist, result);
-
-	if (rc != AEROSPIKE_OK) {
-		LOG("error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
-		exit(1);
-	}
+	as_expbin_puts(&as, &err, NULL, &testKey, (as_list*)&arglist, result);
 
 	LOG("Getting expire bins...");
 
@@ -314,7 +148,7 @@ main(int argc, char* argv[])
 	as_arraylist_append_str(&arglist, "TestBin4");
 	as_arraylist_append_str(&arglist, "TestBin5");
 
-	result = as_expbin_get(&as, &err, NULL, &testKey, (as_list*) &arglist, result);
+	result = as_expbin_get(&as, &err, NULL, &testKey, (as_list*)&arglist, result);
 	LOG("TestBins: %s", as_val_tostring(result));
 
 	LOG("Getting bin TTLs...");
@@ -342,27 +176,22 @@ main(int argc, char* argv[])
 	as_arraylist_append_str(&arglist, "TestBin4");
 	as_arraylist_append_str(&arglist, "TestBin5");
 
-	result = as_expbin_get(&as, &err, NULL, &testKey, (as_list*) &arglist, result);
+	result = as_expbin_get(&as, &err, NULL, &testKey, (as_list*)&arglist, result);
 	LOG("TestBins: %s", as_val_tostring(result));
 
 	LOG("Changing expiration times...");
 
 	as_arraylist_inita(&arglist, 2);
 
-	map1 = create_bin_map("TestBin1", "Good Morning.", 10); 
-	as_val_reserve((as_map *) &map1);
-	as_arraylist_append(&arglist, (as_val *)((as_map *) &map1));
+	map1 = create_bin_map("TestBin1", "Hello World.", 10); 
+	as_val_reserve((as_map *)&map1);
+	as_arraylist_append(&arglist, (as_val *)((as_map *)&map1));
 
-	map2 = create_bin_map("TestBin4", "Good Night.", 5); 
-	as_val_reserve((as_map *) &map2);
-	as_arraylist_append(&arglist, (as_val *)((as_map *) &map2));
+	map2 = create_bin_map("TestBin4", "Good Morning.", 5); 
+	as_val_reserve((as_map *)&map2);
+	as_arraylist_append(&arglist, (as_val *)((as_map *)&map2));
 
-	rc = as_expbin_touch(&as, &err, NULL, &testKey, (as_list*) &arglist, result);
-
-	if (rc != AEROSPIKE_OK) {
-		LOG("error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
-		exit(1);
-	}
+	as_expbin_touch(&as, &err, NULL, &testKey, (as_list*)&arglist, result);
 
 	LOG("Getting bin TTLs...");
 	result = as_expbin_ttl(&as, &err, NULL, &testKey, "TestBin1", result); 
@@ -376,15 +205,226 @@ main(int argc, char* argv[])
 	result = as_expbin_ttl(&as, &err, NULL, &testKey, "TestBin5", result); 
 	LOG("TestBin 5 TTL: %s", as_val_tostring(result));
 
+	LOG("Cleaning bins...");
+
+	as_scan scan;
+
+	as_arraylist_inita(&arglist, 5);
+	as_arraylist_append_str(&arglist, "TestBin1");
+	as_arraylist_append_str(&arglist, "TestBin2");
+	as_arraylist_append_str(&arglist, "TestBin3");
+	as_arraylist_append_str(&arglist, "TestBin4");
+	as_arraylist_append_str(&arglist, "TestBin5");
+
+	LOG("Scan in progress...");
+	as_expbin_clean(&as, &err, NULL, &scan, (as_list*) &arglist);
+	LOG("Scan completed!");
+
+	LOG("Checking expire bins again...");
+
+	as_arraylist_inita(&arglist, 5);
+	as_arraylist_append_str(&arglist, "TestBin1");
+	as_arraylist_append_str(&arglist, "TestBin2");
+	as_arraylist_append_str(&arglist, "TestBin3");
+	as_arraylist_append_str(&arglist, "TestBin4");
+	as_arraylist_append_str(&arglist, "TestBin5");
+
+	result = as_expbin_get(&as, &err, NULL, &testKey, (as_list*) &arglist, result);
+	LOG("TestBins: %s", as_val_tostring(result));
+
 	aerospike_close(&as, &err);
 	aerospike_destroy(&as);
 
 	return 0;
 }
 
-//------------------------------------------------
-// Register a UDF function in the database.
+/*
+ * Attempt to retrieve values from list of bins. The bins
+ * can be expire bins or normal bins.
+ *
+ * \param as      - The aerospike instance to use for this operation.
+ * \param err     - The as_error to be populated if an error occurs.
+ * \param policy  - The policy to use for this operation. If NULL, then the default policy will be used.
+ * \param key     - The key of the record.
+ * \param arglist - The list of bin names to retrieve values from.
+ * \param result  - A list of bin values respective to the list of bin names passed in. 
+ *                  If a bin is expired or empty, the corresponding index in the list will be NULL.
+ * \return        - result if successful, an error otherwise.
+ */
+as_val* 
+as_expbin_get(aerospike* as, as_error* err, as_policy_apply* policy, as_key* key, as_list* arglist, as_val* result)
+{
+	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "get", arglist, &result);
+	
+	if (rc != AEROSPIKE_OK) {
+		LOG("as_expbin_get() returned %d - %s", err->code, err->message);
+		exit(1);
+	}
+	return result;
+}
+
+/*
+ * Create or update expire bins. If bin_ttl is not NULL, all newly created bins
+ * will be expire bins, otherwise, only normal bins will be created and existing 
+ * expire bins will be updated. Note: existing expire bins will not be converted
+ * into normal bins if bin_ttl is NULL.
+ *
+ * \param as      - The aerospike instance to use for this operation.
+ * \param err     - The as_error to be populated if an error occurs.
+ * \param policy  - The policy to use for this operation. If NULL, then the default policy will be used.
+ * \param key     - The key of the record.
+ * \param bin     - Bin name.
+ * \param val     - Bin value.
+ * \param bin_ttl - Expiration time in seconds or -1 for no expiration.
+ * \param result  - 0 if successfully written, 1 otherwise.
+ * \return        - void if successful, an error otherwise.
+ */
+void
+as_expbin_put(aerospike* as, as_error* err, as_policy_apply* policy, as_key* key, char* bin, as_val* val, uint64_t bin_ttl, as_val* result)
+{
+	as_arraylist arglist;
+	as_arraylist_inita(&arglist, 4);
+	as_arraylist_append_str(&arglist, bin);
+	as_arraylist_append(&arglist, val);
+	as_arraylist_append_int64(&arglist, bin_ttl);
+
+	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "put", (as_list*)&arglist, &result);
+	
+	if (rc != AEROSPIKE_OK) {
+		LOG("as_expbin_put() returned %d - %s", err->code, err->message);
+		exit(1);
+	}
+}
+
+/* Batch create or update expire bins for a given key. Use the as_map:
+ * {'bin' : bin_name, 'val' : bin_value, 'bin_ttl' : ttl} to store each put operation.
+ * Omit the bin_ttl to turn bin creation off.
+ *
+ * \param as      - The aerospike instance to use for this operation.
+ * \param err     - The as_error to be populated if an error occurs.
+ * \param policy  - The policy to use for this operation. If NULL, then the default policy will be used.
+ * \param key     - The key of the record.
+ * \param arglist - The list of as_maps in the following form: {'bin' : bin_name, 'val' : bin_value, 'bin_ttl' : ttl}.
+ * \param result  - 0 if all ops succeed, 1 otherwise.
+ * \return        - void if successful, an error otherwise.
+ */
+void 
+as_expbin_puts(aerospike* as, as_error* err, as_policy_apply* policy, as_key* key, as_list* arglist, as_val* result) 
+{
+	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "puts", arglist, &result);
+	
+	if (rc != AEROSPIKE_OK) {
+		LOG("as_expbin_puts() returned %d - %s", err->code, err->message);
+		exit(1);
+	}
+}
+
+/*
+ * Batch update the bin TTLs. Us this method to change or reset the bin TTL of
+ * multiple bins in a record. 
+ *
+ * \param as      - The aerospike instance to use for this operation.
+ * \param err     - The as_error to be populated if an error occurs.
+ * \param policy  - The policy to use for this operation. If NULL, then the default policy will be used.
+ * \param key     - The key of the record.
+ * \param arglist - The list of bin names.
+ * \param result  - 0 if all ops succeed, 1 otherwise.
+ * \return        - void if successful, an error otherwise.
+ */
+void 
+as_expbin_touch(aerospike* as, as_error* err, as_policy_apply* policy, as_key* key, as_list* arglist, as_val* result) 
+{
+	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "touch", arglist, &result);
+	
+	if (rc != AEROSPIKE_OK) {
+		LOG("as_expbin_touch() returned %d - %s", err->code, err->message);	
+		exit(1);
+	}
+}
+
+/*
+ * Get the time bin will expire in seconds.
+ *
+ * \param as      - The aerospike instance to use for this operation.
+ * \param err     - The as_error to be populated if an error occurs.
+ * \param policy  - The policy to use for this operation. If NULL, then the default policy will be used.
+ * \param key     - The key of the record.
+ * \param arglist - The bin name to check.
+ * \param result  - Bin time to expire in seconds.
+ * \return        - result if successful, an error otherwise.
+ */
+as_val*
+as_expbin_ttl(aerospike* as, as_error* err, as_policy_apply* policy, as_key* key, char* bin_name, as_val* result) 
+{
+	as_arraylist arglist;
+	as_arraylist_inita(&arglist, 1);
+	as_arraylist_append_str(&arglist, bin_name);
+
+	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "ttl", (as_list*) &arglist, &result);
+	
+	if (rc != AEROSPIKE_OK) {
+		LOG("as_expbin_ttl() returned %d - %s", err->code, err->message);
+		exit(1);	
+	}
+	return result;
+}
+
+/* 
+ * Perform a background scan and remove all expired bins.
+ * 
+ * \param as      - The aerospike instance to use for this operation.
+ * \param err     - The as_error to be populated if an error occurs.
+ * \param policy  - The policy to use for this operation. If NULL, then the default policy will be used.
+ * \param scan    - as_scan to execute scan on.
+ * \param binlist - List of bins to clean.
+ * \return        - void if successful, an error otherwise.
+ */
+void
+as_expbin_clean(aerospike* as, as_error* err, const as_policy_scan* policy, as_scan* scan, as_list* binlist)
+{
+	uint64_t scan_id = 0;
+	as_scan_init(scan, eb_namespace, eb_set);
+
+	if (as_scan_apply_each(scan, UDF_MODULE, "clean", binlist) != true) {
+		LOG("UDF apply failed");
+		exit(1);
+	}
+
+	as_status rc = aerospike_scan_background(as, err, policy, scan, &scan_id);
+	aerospike_scan_wait(as, err, NULL, scan_id, 0);
+
+	if (rc != AEROSPIKE_OK) {
+		LOG("as_expbin_clean() returned %d - %s", err->code, err->message);
+		exit(1);
+	} 
+}
+
+/*
+ * Generate maps for use with batch put and touch operations.
+ *
+ * \param bin_name - name of bin to perform op on.
+ * \param val      - value of bin.
+ * \param bin_ttl  - bin_ttl for bin (-1 for no expiration, 0 to create normal bin).
+ * \return         - as_hashmap.
+ */
+as_hashmap 
+create_bin_map(char* bin_name, char* val, int64_t bin_ttl) 
+{
+	as_hashmap map;
+	as_hashmap_init(&map, 1);
+	as_stringmap_set_str((as_map *) &map, "bin", bin_name);
+	as_stringmap_set_str((as_map *) &map, "val", val);
+	as_stringmap_set_int64((as_map *) &map, "bin_ttl", bin_ttl);
+
+	return map;
+}
+
+//==========================================================
+// Helpers
 //
+
+// Register a UDF function in the database.
+
 bool
 register_udf(aerospike* p_as, const char* udf_file_path)
 {
@@ -444,23 +484,18 @@ register_udf(aerospike* p_as, const char* udf_file_path)
 	return err.code == AEROSPIKE_OK;
 }
 
-//------------------------------------------------
-// Remove the test record from database, and
-// disconnect from cluster.
-//
+// Remove the record from database, and disconnect from cluster.
+
 void
-cleanup(aerospike * as, as_error * err, const as_policy_remove * policy, const as_key * testKey)
+cleanup(aerospike* as, as_error* err, as_policy_remove* policy, as_key* testKey)
 {
 	// Clean up the database. Note that with database "storage-engine device"
 	// configurations, this record may come back to life if the server is re-
-	// started. That's why examples that want to start clean remove the test
+	// started. That's why this example that want to start clean removes the 
 	// record at the beginning.
 	
-	// Remove the test record from the database.
+	// Remove the record from the database.
 	aerospike_key_remove(as, err, NULL, testKey);
-
-	// Note also example_remove_test_records() is not called here - examples
-	// using multiple records call that from their own cleanup utilities.
 
 	// Disconnect from the database cluster and clean up the aerospike object.
 	aerospike_close(as, err);

--- a/src/c/expire_bin.c
+++ b/src/c/expire_bin.c
@@ -14,21 +14,35 @@
  * limitations under the License.
  */
 
+#include <errno.h>
+#include <time.h>
+
 #include <aerospike/aerospike.h>
 #include <aerospike/aerospike_key.h>
+#include <aerospike/aerospike_scan.h>
 #include <aerospike/as_arraylist.h>
 #include <aerospike/as_error.h>
 #include <aerospike/as_integer.h>
-#include <aerospike/as_list.h>
-#include <aerospike/as_record.h>
 #include <aerospike/as_status.h>
 #include <aerospike/as_val.h>
 #include <aerospike/as_scan.h>
 #include <aerospike/as_key.h>
+#include <aerospike/as_map.h>
+#include <aerospike/aerospike_udf.h>
+#include <aerospike/as_config.h>
+#include <aerospike/as_string.h>
+#include <aerospike/as_hashmap.h>
+#include <aerospike/as_stringmap.h>
 
 #define UDF_MODULE "expire_bin"
+#define UDF_USER_PATH "../../"
+const char UDF_FILE_PATH[] = UDF_USER_PATH UDF_MODULE ".lua";
+
 #define LOG(_fmt, _args...) { printf(_fmt "\n", ## _args); fflush(stdout); }
 
+bool register_udf(aerospike* p_as, const char* udf_file_path);
+void cleanup(aerospike * as, as_error * err, const as_policy_remove * policy, const as_key * key);
+void remove_test_record(aerospike* p_as);
 
 /*
  * Attempt to retrieve values from list of bins. The bins
@@ -43,19 +57,31 @@
  *        corresponding index in the list will be NULL.
  * \return AEROSPIKE_OK if successful, otherwise an error.
  */
-as_status
-as_expbin_get(aerospike* as,
-		as_error* err,
-		const as_policy_apply* policy,
-		const as_key* key,
-		as_list* arglist,
-		as_val** result)
+
+as_hashmap 
+create_bin_map(const char* bin_name, const char* val, int64_t bin_ttl) 
 {
-	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "get", arglist, result);
+	as_hashmap map;
+	as_hashmap_init(&map, 1);
+	as_stringmap_set_str((as_map *) &map, "bin", bin_name);
+	as_stringmap_set_str((as_map *) &map, "val", val);
+	as_stringmap_set_int64((as_map *) &map, "bin_ttl", bin_ttl);
+
+	return map;
+}
+
+as_val* 
+as_expbin_get(aerospike* as, as_error* err, const as_policy_apply* policy, const as_key* key, as_list* arglist, as_val* result)
+{
+	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "get", arglist, &result);
 	if (rc != AEROSPIKE_OK) {
 		LOG("as_expbin_get() returned %d - %s", err->code, err->message);
+		exit(1);
 	}
-	return rc;
+
+	//LOG("%d RESULT %s", rc, as_val_tostring(result));
+	
+	return result;
 }
 
 /*
@@ -85,7 +111,6 @@ as_expbin_put(aerospike* as, as_error* err, const as_policy_apply* policy, const
 	as_arraylist_append(&arglist, val);
 	as_arraylist_append_int64(&arglist, bin_ttl);
 
-
 	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "put", (as_list*)&arglist, result);
 	if (rc != AEROSPIKE_OK) {
 		LOG("as_expbin_put() returned %d - %s", err->code, err->message);
@@ -107,9 +132,9 @@ as_expbin_put(aerospike* as, as_error* err, const as_policy_apply* policy, const
  * \return AEROSPIKE_OK if successful, otherwise an error
  */
 as_status 
-as_expbin_puts(aerospike* as, as_error* err, const as_policy_apply* policy, const as_key* key, as_list* arglist, as_val** result) 
+as_expbin_puts(aerospike* as, as_error* err, const as_policy_apply* policy, const as_key* key, as_list* arglist, as_val* result) 
 {
-	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "puts", arglist, result);
+	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "puts", arglist, &result);
 	if (rc != AEROSPIKE_OK) {
 		LOG("as_expbin_puts() returned %d - %s", err->code, err->message);
 	}
@@ -130,9 +155,9 @@ as_expbin_puts(aerospike* as, as_error* err, const as_policy_apply* policy, cons
  * \return AEROSPIKE_OK if successful, otherwise an error
  */
 as_status 
-as_expbin_touch(aerospike* as, as_error* err, const as_policy_apply* policy, const as_key* key, as_list* arglist, as_val** result) 
+as_expbin_touch(aerospike* as, as_error* err, const as_policy_apply* policy, const as_key* key, as_list* arglist, as_val* result) 
 {
-	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "touch", arglist, result);
+	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "touch", arglist, &result);
 	if (rc != AEROSPIKE_OK) {
 		LOG("as_expbin_touch() returned %d - %s", err->code, err->message);	
 	}
@@ -151,14 +176,18 @@ as_expbin_touch(aerospike* as, as_error* err, const as_policy_apply* policy, con
  * 
  * \return AEROSPIKE_OK if successful, otherwise an error
  */
-as_status 
-as_expbin_ttl(aerospike* as, as_error* err, const as_policy_apply* policy, const as_key* key, as_list* arglist, as_val** result) 
+as_val*
+as_expbin_ttl(aerospike* as, as_error* err, const as_policy_apply* policy, const as_key* key, const char* bin_name, as_val* result) 
 {
-	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "ttl", arglist, result);
+	as_arraylist arglist;
+	as_arraylist_inita(&arglist, 1);
+	as_arraylist_append_str(&arglist, bin_name);
+
+	as_status rc = aerospike_key_apply(as, err, policy, key, UDF_MODULE, "ttl", (as_list*) &arglist, &result);
 	if (rc != AEROSPIKE_OK) {
 		LOG("as_expbin_ttl() returned %d - %s", err->code, err->message);	
 	}
-	return rc;
+	return result;
 }
 
 /* 
@@ -175,13 +204,14 @@ as_expbin_ttl(aerospike* as, as_error* err, const as_policy_apply* policy, const
 uint64_t
 as_expbin_clean(aerospike* as, as_error* err, const as_policy_scan* policy, as_scan* scan, as_list* binlist)
 {
-	uint64_t scan_id = NULL;
+	uint64_t scan_id;
 	if (as_scan_apply_each(scan, UDF_MODULE, "clean", binlist) != true) {
 		LOG("UDF apply failed");
 	}
 	as_status rc = aerospike_scan_background(as, err, policy, scan, &scan_id);
 	if (rc != AEROSPIKE_OK) {
-		return NULL;
+		LOG("as_expbin_clean() returned %d - %s", err->code, err->message);
+		exit(1);
 	} else {
 		return scan_id;
 	}
@@ -194,79 +224,245 @@ as_expbin_clean(aerospike* as, as_error* err, const as_policy_scan* policy, as_s
 int
 main(int argc, char* argv[]) 
 {
+	LOG("This is a demo of the expirable bin module for C");
+
 	aerospike as;
 	as_config config;
 	as_error err;
-	as_status rc;
+
 	as_config_init(&config);
 	as_config_add_host(&config, "127.0.0.1", 3000);
 	aerospike_init(&as, &config);
 
-	printf("Connecting to Aerospike server...\n");
-	if ( aerospike_connect(&as, &err) != AEROSPIKE_OK ) {
-		fprintf(stderr, "error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
+	LOG("Connecting to Aerospike server...");
+	if (aerospike_connect(&as, &err) != AEROSPIKE_OK) {
+		LOG("error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
 		exit(1);
 	}
-	printf("Connected!\n");
 
+	LOG("Connected!");
+
+	as_key testKey;
 	
-	as_key key1, key2, key3;
-	
-	printf("Creating expire bins...\n");
-	
-	if (as_key_init_str(&key1, "test", "expireBin", "eb1") == NULL ||
-		as_key_init_str(&key2, "test", "expireBin", "eb2") == NULL ||
-		as_key_init_str(&key3, "test", "expireBin", "eb3") == NULL) {
-		printf("Keys were not initiated.\n");
+	if (as_key_init_str(&testKey, "test", "expireBin", "eb") == NULL) {
+		LOG("Key was not initiated.");
 		exit(1);
 	}
+
+	LOG("Registering UDF...");
+
+	if (! register_udf(&as, UDF_FILE_PATH)) {
+		LOG("Error registering UDF!")
+		cleanup(&as, &err, NULL, &testKey);
+		exit(-1);
+	}
+
+	LOG("UDF registered!");
+
 	as_val* result = NULL;
 	as_string val;
-	as_string_init(&val, "Hello World.", false);
-
-	rc = as_expbin_put(&as, &err, NULL, &key1, "TestBin", (as_val*)&val, -1, &result);
-	if (rc != AEROSPIKE_OK) {
-		exit(1);
-	}
-
-	as_string_init(&val, "This is an expire bin.", false);
-
-	rc = as_expbin_put(&as, &err, NULL, &key2, "TestBin", (as_val*)&val, -1, &result);
-	if (rc != AEROSPIKE_OK) {
-		exit(1);
-	}
-
-	as_string_init(&val, "This bin will expire.", false);
-
-	rc = as_expbin_put(&as, &err, NULL, &key2, "TestBin", (as_val*)&val, 5, &result);
-	if (rc != AEROSPIKE_OK) {
-		exit(1);
-	}
-	
-	printf("Getting expire bins...\n");
-
+	as_status rc;
 	as_arraylist arglist;
-	as_arraylist_inita(&arglist, 1);
-	as_arraylist_append_str(&arglist, "TestBin");
 
-	rc = as_expbin_get(&as, &err, NULL, &key1, (as_list*)&arglist, &result);
+	LOG("Creating expire bins...");
+	
+	as_string_init(&val, "Hello World.", false);
+	rc = as_expbin_put(&as, &err, NULL, &testKey, "TestBin1", (as_val*) &val, -1, &result);
+	if (rc != AEROSPIKE_OK) {
+		LOG("error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
+		exit(1);
+	}
 
-	printf("TestBin 1: %s\n", as_string_tostring(as_string_fromval(result)));
+	as_string_init(&val, "I don't expire.", false);
+	rc = as_expbin_put(&as, &err, NULL, &testKey, "TestBin2", (as_val*) &val, -1, &result);
+	if (rc != AEROSPIKE_OK) {
+		LOG("error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
+		exit(1);
+	}
 
+	as_string_init(&val, "I will expire soon.", false);
+	rc = as_expbin_put(&as, &err, NULL, &testKey, "TestBin3", (as_val*) &val, 5, &result);
+	if (rc != AEROSPIKE_OK) {
+		LOG("error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
+		exit(1);
+	}
 
-	rc = as_expbin_get(&as, &err, NULL, &key2, (as_list*)&arglist, &result);
+	as_hashmap map1, map2; 
+	as_arraylist_inita(&arglist, 2);
 
-	printf("TestBin 2: %s\n", as_string_tostring(as_string_fromval(result)));
+	map1 = create_bin_map("TestBin4", "Good Morning.", 100); 
+	as_val_reserve((as_map *) &map1);
+	as_arraylist_append(&arglist, (as_val *)((as_map *) &map1));
 
+	map2 = create_bin_map("TestBin5", "Good Night.", 0); 
+	as_val_reserve((as_map *) &map2);
+	as_arraylist_append(&arglist, (as_val *)((as_map *) &map2));
 
-	rc = as_expbin_get(&as, &err, NULL, &key3, (as_list*)&arglist, &result);
+	rc = as_expbin_puts(&as, &err, NULL, &testKey, (as_list*) &arglist, result);
 
-	printf("TestBin 3: %s\n", as_string_tostring(as_string_fromval(result)));
+	if (rc != AEROSPIKE_OK) {
+		LOG("error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
+		exit(1);
+	}
 
+	LOG("Getting expire bins...");
 
+	as_arraylist_inita(&arglist, 5);
+	as_arraylist_append_str(&arglist, "TestBin1");
+	as_arraylist_append_str(&arglist, "TestBin2");
+	as_arraylist_append_str(&arglist, "TestBin3");
+	as_arraylist_append_str(&arglist, "TestBin4");
+	as_arraylist_append_str(&arglist, "TestBin5");
+
+	result = as_expbin_get(&as, &err, NULL, &testKey, (as_list*) &arglist, result);
+	LOG("TestBins: %s", as_val_tostring(result));
+
+	LOG("Getting bin TTLs...");
+	result = as_expbin_ttl(&as, &err, NULL, &testKey, "TestBin1", result); 
+	LOG("TestBin 1 TTL: %s", as_val_tostring(result));
+	result = as_expbin_ttl(&as, &err, NULL, &testKey, "TestBin2", result); 
+	LOG("TestBin 2 TTL: %s", as_val_tostring(result));
+	result = as_expbin_ttl(&as, &err, NULL, &testKey, "TestBin3", result); 
+	LOG("TestBin 3 TTL: %s", as_val_tostring(result));
+	result = as_expbin_ttl(&as, &err, NULL, &testKey, "TestBin4", result); 
+	LOG("TestBin 4 TTL: %s", as_val_tostring(result));
+	result = as_expbin_ttl(&as, &err, NULL, &testKey, "TestBin5", result); 
+	LOG("TestBin 5 TTL: %s", as_val_tostring(result));
+
+	LOG("Waiting for TestBin 3 to expire...");
+
+	sleep(10);
+
+	LOG("Getting expire bins again...");
+
+	as_arraylist_inita(&arglist, 5);
+	as_arraylist_append_str(&arglist, "TestBin1");
+	as_arraylist_append_str(&arglist, "TestBin2");
+	as_arraylist_append_str(&arglist, "TestBin3");
+	as_arraylist_append_str(&arglist, "TestBin4");
+	as_arraylist_append_str(&arglist, "TestBin5");
+
+	result = as_expbin_get(&as, &err, NULL, &testKey, (as_list*) &arglist, result);
+	LOG("TestBins: %s", as_val_tostring(result));
+
+	LOG("Changing expiration times...");
+
+	as_arraylist_inita(&arglist, 2);
+
+	map1 = create_bin_map("TestBin1", "Good Morning.", 10); 
+	as_val_reserve((as_map *) &map1);
+	as_arraylist_append(&arglist, (as_val *)((as_map *) &map1));
+
+	map2 = create_bin_map("TestBin4", "Good Night.", 5); 
+	as_val_reserve((as_map *) &map2);
+	as_arraylist_append(&arglist, (as_val *)((as_map *) &map2));
+
+	rc = as_expbin_touch(&as, &err, NULL, &testKey, (as_list*) &arglist, result);
+
+	if (rc != AEROSPIKE_OK) {
+		LOG("error(%d) %s at [%s:%d]", err.code, err.message, err.file, err.line);
+		exit(1);
+	}
+
+	LOG("Getting bin TTLs...");
+	result = as_expbin_ttl(&as, &err, NULL, &testKey, "TestBin1", result); 
+	LOG("TestBin 1 TTL: %s", as_val_tostring(result));
+	result = as_expbin_ttl(&as, &err, NULL, &testKey, "TestBin2", result); 
+	LOG("TestBin 2 TTL: %s", as_val_tostring(result));
+	result = as_expbin_ttl(&as, &err, NULL, &testKey, "TestBin3", result); 
+	LOG("TestBin 3 TTL: %s", as_val_tostring(result));
+	result = as_expbin_ttl(&as, &err, NULL, &testKey, "TestBin4", result); 
+	LOG("TestBin 4 TTL: %s", as_val_tostring(result));
+	result = as_expbin_ttl(&as, &err, NULL, &testKey, "TestBin5", result); 
+	LOG("TestBin 5 TTL: %s", as_val_tostring(result));
 
 	aerospike_close(&as, &err);
 	aerospike_destroy(&as);
 
 	return 0;
+}
+
+//------------------------------------------------
+// Register a UDF function in the database.
+//
+bool
+register_udf(aerospike* p_as, const char* udf_file_path)
+{
+	FILE* file = fopen(udf_file_path, "r");
+
+	if (! file) {
+		// If we get here it's likely that we're not running the example from
+		// the right directory - the specific example directory.
+		LOG("cannot open script file %s : %s", udf_file_path, strerror(errno));
+		return false;
+	}
+
+	// Read the file's content into a local buffer.
+
+	uint8_t* content = (uint8_t*)malloc(1024 * 1024);
+
+	if (! content) {
+		LOG("script content allocation failed");
+		return false;
+	}
+
+	uint8_t* p_write = content;
+	int read = (int)fread(p_write, 1, 512, file);
+	int size = 0;
+
+	while (read) {
+		size += read;
+		p_write += read;
+		read = (int)fread(p_write, 1, 512, file);
+	}
+
+	fclose(file);
+
+	// Wrap the local buffer as an as_bytes object.
+	as_bytes udf_content;
+	as_bytes_init_wrap(&udf_content, content, size, true);
+
+	as_error err;
+	as_string base_string;
+	const char* base = as_basename(&base_string, udf_file_path);
+
+	// Register the UDF file in the database cluster.
+	if (aerospike_udf_put(p_as, &err, NULL, base, AS_UDF_TYPE_LUA,
+			&udf_content) == AEROSPIKE_OK) {
+		// Wait for the system metadata to spread to all nodes.
+		aerospike_udf_put_wait(p_as, &err, NULL, base, 100);
+	}
+	else {
+		LOG("aerospike_udf_put() returned %d - %s", err.code, err.message);
+	}
+
+	as_string_destroy(&base_string);
+
+	// This frees the local buffer.
+	as_bytes_destroy(&udf_content);
+
+	return err.code == AEROSPIKE_OK;
+}
+
+//------------------------------------------------
+// Remove the test record from database, and
+// disconnect from cluster.
+//
+void
+cleanup(aerospike * as, as_error * err, const as_policy_remove * policy, const as_key * testKey)
+{
+	// Clean up the database. Note that with database "storage-engine device"
+	// configurations, this record may come back to life if the server is re-
+	// started. That's why examples that want to start clean remove the test
+	// record at the beginning.
+	
+	// Remove the test record from the database.
+	aerospike_key_remove(as, err, NULL, testKey);
+
+	// Note also example_remove_test_records() is not called here - examples
+	// using multiple records call that from their own cleanup utilities.
+
+	// Disconnect from the database cluster and clean up the aerospike object.
+	aerospike_close(as, err);
+	aerospike_destroy(as);
 }

--- a/src/java/ExpireBin.java
+++ b/src/java/ExpireBin.java
@@ -4,7 +4,7 @@
 //   you may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,36 +30,37 @@ import com.aerospike.client.task.ExecuteTask;
 import com.aerospike.client.task.RegisterTask;
 
 public class ExpireBin {
-	private static final String GET_OP = "get";
-	private static final String PUT_OP = "put";
-	private static final String BATCH_PUT_OP = "puts";
-	private static final String TOUCH_OP = "touch";
-	private static final String CLEAN_OP = "clean";
-	private static final String TTL_OP = "ttl";
-	private static final String MODULE_NAME = "expire_bin";
-	private static final String BIN_NAME_FIELD = "bin";
+	private static final String GET_OP 			= "get";
+	private static final String PUT_OP 			= "put";
+	private static final String BATCH_PUT_OP 	= "puts";
+	private static final String TOUCH_OP 		= "touch";
+	private static final String CLEAN_OP 		= "clean";
+	private static final String TTL_OP 			= "ttl";
+	private static final String MODULE_NAME     = "expire_bin";
+	private static final String BIN_NAME_FIELD  = "bin";
 	private static final String BIN_VALUE_FIELD = "val";
-	private static final String BIN_TTL_FIELD = "bin_ttl";
+	private static final String BIN_TTL_FIELD   = "bin_ttl";
+	
 	public AerospikeClient client;
 
 	/**
-	 * Initialize ExpireBin object with suitable client and policy
+	 * Initialize ExpireBin object with suitable client and policy.
 	 * 
-	 * @param client - client to perform operations on
+	 * @param client - Client to perform operations on.
 	 */
 	public ExpireBin(AerospikeClient client) {
 		this.client = client;
 	}
 
 	/**
-	 * Try to get values from the expire bin
+	 * Try to get values from the expire bin.
 	 * 
-	 * @param policy - configuration parameters for op
-	 * @param - key to get from
-	 * @param bins - list of bin names to attempt to get from
-	 * @return Record containing respective values for bins that haven't
-	 * expired / exist. The gen and exp numbers on the Record are not valid.
-	 * @throws AerospikeException 
+	 * @param policy - Configuration parameters for op.
+	 * @param key    - Key to get from.
+	 * @param bins   - List of bin names to attempt to get from.
+	 * @return       - Record containing respective values for bins that haven't
+	 * 		   		   expired/exist. The gen and exp numbers on the Record are not valid.
+	 * @throws       - AerospikeException.
 	 */
 	public Object get(Policy policy, Key key, String ... bins) throws AerospikeException {
 		Value[] valueBins = new Value[bins.length];
@@ -83,52 +84,50 @@ public class ExpireBin {
 		} else if (returnVal == null) {
 			return null;
 		}else {
-			throw new AerospikeException("Get operation failed.");
+			throw new AerospikeException("Get operation failed");
 		}
 	}
 
 	/**
-	 * Create or update expire bins. If the binTTL is not null, 
-	 * all newly created bins will be expire bins otherwise, only normal bins will be created
-	 * Note: existing expire bins will not be converted
-	 * into normal bins if binTTL is not specified
+	 * Create or update expire bins. If the binTTL is not null, all newly created bins will be expire  
+	 * bin, otherwise, only normal bins will be created.
+	 * Note: Existing expire bins will not be converted into normal bins if binTTL is not specified.
 	 * 
-	 * @param policy - configuration parameters for op
-	 * @param key - Record key to apply operation on
-	 * @param binName - Bin name to create or update
-	 * @param val - bin value
-	 * @param binTTL - expiration time in seconds or -1 for no expiration
-	 * @return 0 in success, 1 if error
-	 * @throws AerospikeException 
+	 * @param policy  - Configuration parameters for op.
+	 * @param key     - Record key to apply operation on.
+	 * @param binName - Bin name to create or update.
+	 * @param val     - Bin value.
+	 * @param binTTL  - Expiration time in seconds or -1 for no expiration.
+	 * @return        - 0 if success, 1 if error.
+	 * @throws        - AerospikeException.
 	 */
 	public Integer put(Policy policy, Key key, String binName, Value val, int binTTL) throws AerospikeException {
 		return (Integer) client.execute(policy, key, MODULE_NAME, PUT_OP, Value.get(binName), val, Value.get(binTTL));
 	}
 
 	/**
-	 * Batch create or update expire bins for a given key. Use the createBinMap
-	 * method to create each put operation. Supply a binTTL of 0 to turn bin 
-	 * creation off. 
+	 * Batch create or update expire bins for a given key. Use the createBinMap method
+	 * to create each put operation. Supply a binTTL of 0 to turn bin creation off.  
 	 * 
-	 * @param policy - configuration parameters for op
-	 * @param key - Record key to store bins
-	 * @param mapBins - list of Maps generated by createBinMap containing operation arguments
-	 * @return - 0 if all bins succeeded, 1 if failure
-	 * @throws AerospikeException 
+	 * @param policy  - Configuration parameters for op.
+	 * @param key     - Record key to store bins.
+	 * @param mapBins - List of Maps generated by createBinMap containing operation arguments.
+	 * @return        - 0 if all bins succeeded, 1 if failure.
+	 * @throws        - AerospikeException.
 	 */
 	public Integer puts(Policy policy, Key key, MapValue ... mapBins) throws AerospikeException {
-		return (Integer)client.execute(policy, key, MODULE_NAME, BATCH_PUT_OP, (Value[]) mapBins);
+		return (Integer) client.execute(policy, key, MODULE_NAME, BATCH_PUT_OP, (Value[]) mapBins);
 	}
 
 	/**
 	 * Batch update the bin TTLs. Use this method to change or reset 
 	 * the bin TTL of multiple bins in a record. 
 	 * 
-	 * @param policy - configuration parameters for op
-	 * @param key - Record key
-	 * @param mapBins - list of MapValues generated by createMapBin containing operation arguments
-	 * @return 0 on success of all touch operations, 1 if a failure occurs
-	 * @throws AerospikeException 
+	 * @param policy  - Configuration parameters for op.
+	 * @param key     - Record key.
+	 * @param mapBins - List of MapValues generated by createMapBin containing operation arguments.
+	 * @return 		  - 0 on success of all touch operations, 1 if a failure occurs.
+	 * @throws        - AerospikeException.
 	 */
 	public Integer touch(Policy policy, Key key, MapValue ... mapBins) throws AerospikeException {
 		for (Value.MapValue map : mapBins) {
@@ -137,18 +136,18 @@ public class ExpireBin {
 				throw new AerospikeException("TTL not specified");
 			}
 		}
-		return (Integer)client.execute(policy, key, MODULE_NAME, TOUCH_OP, (Value[]) mapBins);
+		return (Integer) client.execute(policy, key, MODULE_NAME, TOUCH_OP, (Value[]) mapBins);
 	}
 
 	/**
-	 * Perform a scan of the database and clear out expired expire bins
+	 * Perform a scan of the database and clear out expired expire bins.
 	 * 
-	 * @param policy - configuration parameters for op
-	 * @param scan - scan policy containing which records should be scanned
-	 * @param namespace - namespace of server to scan
-	 * @param set - set of server to scan
-	 * @param bins - list of bins to scan
-	 * @throws AerospikeException 
+	 * @param policy    - Configuration parameters for op.
+	 * @param scan      - Scan policy containing which records should be scanned.
+	 * @param namespace - Namespace of server to scan.
+	 * @param set       - Set of server to scan.
+	 * @param bins      - List of bins to scan.
+	 * @throws          - AerospikeException.
 	 */
 	public ExecuteTask clean(Policy policy, Statement statement, String ... bins) throws AerospikeException {
 		final Value[] valueBins = new Value[bins.length];
@@ -163,24 +162,24 @@ public class ExpireBin {
 	/**
 	 * Get time bin will expire in seconds.
 	 * 
-	 * @param policy - configuration parameters for op
-	 * @param key - Record key
-	 * @param bin - Bin Name
-	 * @return time in seconds bin will expire, -1 or null if it doesn't expire
-	 * @throws AerospikeException 
+	 * @param policy - Configuration parameters for op.
+	 * @param key    - Record key.
+	 * @param bin    - Bin Name.
+	 * @return       - Time in seconds bin will expire, -1 or null if it doesn't expire.
+	 * @throws       - AerospikeException. 
 	 */
 	public Integer ttl(Policy policy, Key key, String bin) throws AerospikeException {
-		return (Integer)(client.execute(policy, key, MODULE_NAME, TTL_OP, Value.get(bin)));
+		return (Integer) (client.execute(policy, key, MODULE_NAME, TTL_OP, Value.get(bin)));
 	}
 	
 	/**
-	 * createBinMap is used to generate maps for use with batch put and touch operations.
+	 * Used to generate maps for use with batch put and touch operations.
 	 * 
-	 * @param binName - name of bin to perform op on
-	 * @param val - value to insert into bin (PUT OP ONLY)
-	 * @param binTTL - bin_ttl for bin (-1 for no expiration, 0 to create normal bin)
-	 * @return
-	 * @throws AerospikeException 
+	 * @param binName - Name of bin to perform op on.
+	 * @param val     - Value to insert into bin (PUT OP ONLY).
+	 * @param binTTL  - Bin ttl for bin (-1 for no expiration, 0 to create normal bin).
+	 * @return        - The generated map.
+	 * @throws        - AerospikeException.
 	 */
 	public static MapValue createBinMap(String binName, Value val, int binTTL) throws AerospikeException {
 		HashMap<String, Object> rm = new HashMap<String, Object>();
@@ -192,9 +191,7 @@ public class ExpireBin {
 		if (val != null) {
 			rm.put(BIN_VALUE_FIELD, val);
 		}
-		
 		rm.put (BIN_TTL_FIELD, binTTL);
-		
 		return new MapValue(rm);
 	}
 	
@@ -202,7 +199,7 @@ public class ExpireBin {
 		AerospikeClient testClient = null;
 		System.out.println("This is a demo of the expirable bin module for Java");
 		try {
-			System.out.println("Connecting to server...");
+			System.out.println("Connecting to Aerospike server...");
 			testClient = new AerospikeClient("127.0.0.1", 3000);
 			System.out.println("Connected!");
 			Policy policy = new WritePolicy();
@@ -222,14 +219,14 @@ public class ExpireBin {
 			System.out.println("Creating expire bins...");
 			Key testKey = new Key("test", "expireBin", "eb");
 
-			System.out.println(eb.put(policy, testKey, "TestBin1", Value.get("Hello World"), -1) == 0 ? "TestBin 1 inserted." : "TestBin 1 not inserted");
-			System.out.println(eb.put(policy, testKey, "TestBin2", Value.get("I don't expire"), -1) == 0 ? "TestBin 2 inserted" : "TestBin 2 not inserted");
-			System.out.println(eb.put(policy, testKey, "TestBin3", Value.get("I will expire soon"), 5) == 0 ? "TestBin 3 inserted" : "TestBin 3 not inserted");
+			System.out.println(eb.put(policy, testKey, "TestBin1", Value.get("Hello World."), -1) == 0 ? "TestBin 1 inserted." : "TestBin 1 not inserted");
+			System.out.println(eb.put(policy, testKey, "TestBin2", Value.get("I don't expire."), -1) == 0 ? "TestBin 2 inserted" : "TestBin 2 not inserted");
+			System.out.println(eb.put(policy, testKey, "TestBin3", Value.get("I will expire soon."), 5) == 0 ? "TestBin 3 inserted" : "TestBin 3 not inserted");
 			System.out.println(eb.puts(policy, testKey, createBinMap("TestBin4", Value.get("Good Morning."), 100), 
 					createBinMap("TestBin5", Value.get("Good Night."), 0)) == 0 ? "TestBin 4 & 5 inserted" : "TestBin 4 & 5 not inserted");
 			
 			System.out.println("Getting expire bins...");
-			System.out.println("TestBins : " + eb.get(policy, testKey, "TestBin1", "TestBin2", "TestBin3", "TestBin4", "TestBin5"));
+			System.out.println("TestBins: " + eb.get(policy, testKey, "TestBin1", "TestBin2", "TestBin3", "TestBin4", "TestBin5"));
 			
 			System.out.println("Getting bin TTLs...");
 			System.out.println("TestBin 1 TTL: " + eb.ttl(policy, testKey, "TestBin1"));
@@ -239,7 +236,6 @@ public class ExpireBin {
 			System.out.println("TestBin 5 TTL: " + eb.ttl(policy, testKey, "TestBin5"));
 			
 			System.out.println("Waiting for TestBin 3 to expire...");
-
 			try {
 				TimeUnit.SECONDS.sleep(10);
 			} catch(InterruptedException ex) {
@@ -247,7 +243,7 @@ public class ExpireBin {
 			}
 
 			System.out.println("Getting expire bins again...");
-			System.out.println("TestBins : " + eb.get(policy, testKey, "TestBin1", "TestBin2", "TestBin3", "TestBin4", "TestBin5"));
+			System.out.println("TestBins: " + eb.get(policy, testKey, "TestBin1", "TestBin2", "TestBin3", "TestBin4", "TestBin5"));
 			
 			System.out.println("Changing expiration times...");
 			eb.touch(policy, testKey, createBinMap("TestBin1", null, 10), createBinMap("TestBin4", null, 5));
@@ -273,11 +269,10 @@ public class ExpireBin {
 					Thread.currentThread().interrupt();
 				}
 			}
-			
 			System.out.println("Scan completed!");
 			
 			System.out.println("Checking expire bins again...");
-			System.out.println("TestBins : " + eb.get(policy, testKey, "TestBin1", "TestBin2", "TestBin3", "TestBin4", "TestBin5"));
+			System.out.println("TestBins: " + eb.get(policy, testKey, "TestBin1", "TestBin2", "TestBin3", "TestBin4", "TestBin5"));
 		} catch (AerospikeException e) {
 			e.printStackTrace();
 			System.exit(1);


### PR DESCRIPTION
- Applying ipairs on vararg (...) will result in an exception
- Instead, pack(...) is used to iterate through args
